### PR TITLE
chore: Migrate errorreporting synth.py to bazel

### DIFF
--- a/google-cloud-errorreporting/src/main/java/com/google/cloud/errorreporting/v1beta1/package-info.java
+++ b/google-cloud-errorreporting/src/main/java/com/google/cloud/errorreporting/v1beta1/package-info.java
@@ -19,7 +19,22 @@
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *
- * <p>======================= ErrorStatsServiceClient =======================
+ * <p>======================= ErrorGroupServiceClient =======================
+ *
+ * <p>Service Description: Service for retrieving and updating individual error groups.
+ *
+ * <p>Sample for ErrorGroupServiceClient:
+ *
+ * <pre>
+ * <code>
+ * try (ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.create()) {
+ *   ErrorGroupName groupName = ErrorGroupName.of("[PROJECT]", "[GROUP]");
+ *   ErrorGroup response = errorGroupServiceClient.getGroup(groupName);
+ * }
+ * </code>
+ * </pre>
+ *
+ * ======================= ErrorStatsServiceClient =======================
  *
  * <p>Service Description: An API for retrieving and managing error statistics as well as data for
  * individual events.
@@ -31,21 +46,6 @@
  * try (ErrorStatsServiceClient errorStatsServiceClient = ErrorStatsServiceClient.create()) {
  *   ProjectName projectName = ProjectName.of("[PROJECT]");
  *   DeleteEventsResponse response = errorStatsServiceClient.deleteEvents(projectName);
- * }
- * </code>
- * </pre>
- *
- * ======================= ErrorGroupServiceClient =======================
- *
- * <p>Service Description: Service for retrieving and updating individual error groups.
- *
- * <p>Sample for ErrorGroupServiceClient:
- *
- * <pre>
- * <code>
- * try (ErrorGroupServiceClient errorGroupServiceClient = ErrorGroupServiceClient.create()) {
- *   ErrorGroupName groupName = ErrorGroupName.of("[PROJECT]", "[GROUP]");
- *   ErrorGroup response = errorGroupServiceClient.getGroup(groupName);
  * }
  * </code>
  * </pre>

--- a/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ErrorGroupServiceClientTest.java
+++ b/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ErrorGroupServiceClientTest.java
@@ -42,8 +42,8 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class ErrorGroupServiceClientTest {
-  private static MockErrorStatsService mockErrorStatsService;
   private static MockErrorGroupService mockErrorGroupService;
+  private static MockErrorStatsService mockErrorStatsService;
   private static MockReportErrorsService mockReportErrorsService;
   private static MockServiceHelper serviceHelper;
   private ErrorGroupServiceClient client;
@@ -51,14 +51,14 @@ public class ErrorGroupServiceClientTest {
 
   @BeforeClass
   public static void startStaticServer() {
-    mockErrorStatsService = new MockErrorStatsService();
     mockErrorGroupService = new MockErrorGroupService();
+    mockErrorStatsService = new MockErrorStatsService();
     mockReportErrorsService = new MockReportErrorsService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
-                mockErrorStatsService, mockErrorGroupService, mockReportErrorsService));
+                mockErrorGroupService, mockErrorStatsService, mockReportErrorsService));
     serviceHelper.start();
   }
 

--- a/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ErrorStatsServiceClientTest.java
+++ b/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ErrorStatsServiceClientTest.java
@@ -52,8 +52,8 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class ErrorStatsServiceClientTest {
-  private static MockErrorStatsService mockErrorStatsService;
   private static MockErrorGroupService mockErrorGroupService;
+  private static MockErrorStatsService mockErrorStatsService;
   private static MockReportErrorsService mockReportErrorsService;
   private static MockServiceHelper serviceHelper;
   private ErrorStatsServiceClient client;
@@ -61,14 +61,14 @@ public class ErrorStatsServiceClientTest {
 
   @BeforeClass
   public static void startStaticServer() {
-    mockErrorStatsService = new MockErrorStatsService();
     mockErrorGroupService = new MockErrorGroupService();
+    mockErrorStatsService = new MockErrorStatsService();
     mockReportErrorsService = new MockReportErrorsService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
-                mockErrorStatsService, mockErrorGroupService, mockReportErrorsService));
+                mockErrorGroupService, mockErrorStatsService, mockReportErrorsService));
     serviceHelper.start();
   }
 

--- a/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ReportErrorsServiceClientTest.java
+++ b/google-cloud-errorreporting/src/test/java/com/google/cloud/errorreporting/v1beta1/ReportErrorsServiceClientTest.java
@@ -42,8 +42,8 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class ReportErrorsServiceClientTest {
-  private static MockErrorStatsService mockErrorStatsService;
   private static MockErrorGroupService mockErrorGroupService;
+  private static MockErrorStatsService mockErrorStatsService;
   private static MockReportErrorsService mockReportErrorsService;
   private static MockServiceHelper serviceHelper;
   private ReportErrorsServiceClient client;
@@ -51,14 +51,14 @@ public class ReportErrorsServiceClientTest {
 
   @BeforeClass
   public static void startStaticServer() {
-    mockErrorStatsService = new MockErrorStatsService();
     mockErrorGroupService = new MockErrorGroupService();
+    mockErrorStatsService = new MockErrorStatsService();
     mockReportErrorsService = new MockReportErrorsService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
-                mockErrorStatsService, mockErrorGroupService, mockReportErrorsService));
+                mockErrorGroupService, mockErrorStatsService, mockReportErrorsService));
     serviceHelper.start();
   }
 

--- a/grpc-google-cloud-error-reporting-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-error-reporting-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.119.2-beta released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/devtools/clouderrorreporting/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ErrorGroupServiceGrpc.java
+++ b/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ErrorGroupServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/clouderrorreporting/v1beta1/error_group_service.proto")
 public final class ErrorGroupServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class ErrorGroupServiceGrpc {
       "google.devtools.clouderrorreporting.v1beta1.ErrorGroupService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
-      METHOD_GET_GROUP = getGetGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
       getGetGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetGroup",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
       getGetGroupMethod() {
-    return getGetGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
-      getGetGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
             com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
@@ -78,10 +68,7 @@ public final class ErrorGroupServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ErrorGroupService",
-                              "GetGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -100,30 +87,20 @@ public final class ErrorGroupServiceGrpc {
     return getGetGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
-      METHOD_UPDATE_GROUP = getUpdateGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
       getUpdateGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateGroup",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
       getUpdateGroupMethod() {
-    return getUpdateGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
-      getUpdateGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
             com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
@@ -138,10 +115,7 @@ public final class ErrorGroupServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ErrorGroupService",
-                              "UpdateGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -162,19 +136,43 @@ public final class ErrorGroupServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ErrorGroupServiceStub newStub(io.grpc.Channel channel) {
-    return new ErrorGroupServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceStub>() {
+          @java.lang.Override
+          public ErrorGroupServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorGroupServiceStub(channel, callOptions);
+          }
+        };
+    return ErrorGroupServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ErrorGroupServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ErrorGroupServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceBlockingStub>() {
+          @java.lang.Override
+          public ErrorGroupServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorGroupServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return ErrorGroupServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ErrorGroupServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ErrorGroupServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorGroupServiceFutureStub>() {
+          @java.lang.Override
+          public ErrorGroupServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorGroupServiceFutureStub(channel, callOptions);
+          }
+        };
+    return ErrorGroupServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -197,7 +195,7 @@ public final class ErrorGroupServiceGrpc {
         com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetGroupMethod(), responseObserver);
     }
 
     /**
@@ -212,21 +210,21 @@ public final class ErrorGroupServiceGrpc {
         com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateGroupMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getGetGroupMethodHelper(),
+              getGetGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest,
                       com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>(
                       this, METHODID_GET_GROUP)))
           .addMethod(
-              getUpdateGroupMethodHelper(),
+              getUpdateGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest,
@@ -244,11 +242,7 @@ public final class ErrorGroupServiceGrpc {
    * </pre>
    */
   public static final class ErrorGroupServiceStub
-      extends io.grpc.stub.AbstractStub<ErrorGroupServiceStub> {
-    private ErrorGroupServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ErrorGroupServiceStub> {
     private ErrorGroupServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -271,9 +265,7 @@ public final class ErrorGroupServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetGroupMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetGroupMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -289,7 +281,7 @@ public final class ErrorGroupServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -303,11 +295,7 @@ public final class ErrorGroupServiceGrpc {
    * </pre>
    */
   public static final class ErrorGroupServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<ErrorGroupServiceBlockingStub> {
-    private ErrorGroupServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ErrorGroupServiceBlockingStub> {
     private ErrorGroupServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -328,7 +316,7 @@ public final class ErrorGroupServiceGrpc {
      */
     public com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup getGroup(
         com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest request) {
-      return blockingUnaryCall(getChannel(), getGetGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -341,8 +329,7 @@ public final class ErrorGroupServiceGrpc {
      */
     public com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup updateGroup(
         com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateGroupMethod(), getCallOptions(), request);
     }
   }
 
@@ -354,11 +341,7 @@ public final class ErrorGroupServiceGrpc {
    * </pre>
    */
   public static final class ErrorGroupServiceFutureStub
-      extends io.grpc.stub.AbstractStub<ErrorGroupServiceFutureStub> {
-    private ErrorGroupServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ErrorGroupServiceFutureStub> {
     private ErrorGroupServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -379,8 +362,7 @@ public final class ErrorGroupServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
         getGroup(com.google.devtools.clouderrorreporting.v1beta1.GetGroupRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetGroupMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -395,7 +377,7 @@ public final class ErrorGroupServiceGrpc {
             com.google.devtools.clouderrorreporting.v1beta1.ErrorGroup>
         updateGroup(com.google.devtools.clouderrorreporting.v1beta1.UpdateGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateGroupMethod(), getCallOptions()), request);
     }
   }
 
@@ -497,8 +479,8 @@ public final class ErrorGroupServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ErrorGroupServiceFileDescriptorSupplier())
-                      .addMethod(getGetGroupMethodHelper())
-                      .addMethod(getUpdateGroupMethodHelper())
+                      .addMethod(getGetGroupMethod())
+                      .addMethod(getUpdateGroupMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ErrorStatsServiceGrpc.java
+++ b/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ErrorStatsServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/clouderrorreporting/v1beta1/error_stats_service.proto")
 public final class ErrorStatsServiceGrpc {
 
@@ -41,30 +41,20 @@ public final class ErrorStatsServiceGrpc {
       "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListGroupStatsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
-      METHOD_LIST_GROUP_STATS = getListGroupStatsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
       getListGroupStatsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListGroupStats",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
       getListGroupStatsMethod() {
-    return getListGroupStatsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
-      getListGroupStatsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
             com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
@@ -79,10 +69,7 @@ public final class ErrorStatsServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService",
-                              "ListGroupStats"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListGroupStats"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -101,30 +88,20 @@ public final class ErrorStatsServiceGrpc {
     return getListGroupStatsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListEventsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
-      METHOD_LIST_EVENTS = getListEventsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
       getListEventsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListEvents",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
       getListEventsMethod() {
-    return getListEventsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
-      getListEventsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
             com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
@@ -139,10 +116,7 @@ public final class ErrorStatsServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService",
-                              "ListEvents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListEvents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -161,30 +135,20 @@ public final class ErrorStatsServiceGrpc {
     return getListEventsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteEventsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
-      METHOD_DELETE_EVENTS = getDeleteEventsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
       getDeleteEventsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteEvents",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
           com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
       getDeleteEventsMethod() {
-    return getDeleteEventsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
-      getDeleteEventsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
             com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
@@ -199,10 +163,7 @@ public final class ErrorStatsServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService",
-                              "DeleteEvents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteEvents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -223,19 +184,43 @@ public final class ErrorStatsServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ErrorStatsServiceStub newStub(io.grpc.Channel channel) {
-    return new ErrorStatsServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceStub>() {
+          @java.lang.Override
+          public ErrorStatsServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorStatsServiceStub(channel, callOptions);
+          }
+        };
+    return ErrorStatsServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ErrorStatsServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ErrorStatsServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceBlockingStub>() {
+          @java.lang.Override
+          public ErrorStatsServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorStatsServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return ErrorStatsServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ErrorStatsServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ErrorStatsServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ErrorStatsServiceFutureStub>() {
+          @java.lang.Override
+          public ErrorStatsServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ErrorStatsServiceFutureStub(channel, callOptions);
+          }
+        };
+    return ErrorStatsServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -260,7 +245,7 @@ public final class ErrorStatsServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListGroupStatsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListGroupStatsMethod(), responseObserver);
     }
 
     /**
@@ -275,7 +260,7 @@ public final class ErrorStatsServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListEventsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListEventsMethod(), responseObserver);
     }
 
     /**
@@ -290,28 +275,28 @@ public final class ErrorStatsServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteEventsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteEventsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListGroupStatsMethodHelper(),
+              getListGroupStatsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest,
                       com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>(
                       this, METHODID_LIST_GROUP_STATS)))
           .addMethod(
-              getListEventsMethodHelper(),
+              getListEventsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest,
                       com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>(
                       this, METHODID_LIST_EVENTS)))
           .addMethod(
-              getDeleteEventsMethodHelper(),
+              getDeleteEventsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest,
@@ -330,11 +315,7 @@ public final class ErrorStatsServiceGrpc {
    * </pre>
    */
   public static final class ErrorStatsServiceStub
-      extends io.grpc.stub.AbstractStub<ErrorStatsServiceStub> {
-    private ErrorStatsServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ErrorStatsServiceStub> {
     private ErrorStatsServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -358,7 +339,7 @@ public final class ErrorStatsServiceGrpc {
                 com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListGroupStatsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListGroupStatsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -376,9 +357,7 @@ public final class ErrorStatsServiceGrpc {
                 com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListEventsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListEventsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -394,7 +373,7 @@ public final class ErrorStatsServiceGrpc {
                 com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteEventsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteEventsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -409,11 +388,7 @@ public final class ErrorStatsServiceGrpc {
    * </pre>
    */
   public static final class ErrorStatsServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<ErrorStatsServiceBlockingStub> {
-    private ErrorStatsServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ErrorStatsServiceBlockingStub> {
     private ErrorStatsServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -434,8 +409,7 @@ public final class ErrorStatsServiceGrpc {
      */
     public com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsResponse listGroupStats(
         com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListGroupStatsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListGroupStatsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -447,8 +421,7 @@ public final class ErrorStatsServiceGrpc {
      */
     public com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse listEvents(
         com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEventsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListEventsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -460,8 +433,7 @@ public final class ErrorStatsServiceGrpc {
      */
     public com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse deleteEvents(
         com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteEventsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteEventsMethod(), getCallOptions(), request);
     }
   }
 
@@ -474,11 +446,7 @@ public final class ErrorStatsServiceGrpc {
    * </pre>
    */
   public static final class ErrorStatsServiceFutureStub
-      extends io.grpc.stub.AbstractStub<ErrorStatsServiceFutureStub> {
-    private ErrorStatsServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ErrorStatsServiceFutureStub> {
     private ErrorStatsServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -501,7 +469,7 @@ public final class ErrorStatsServiceGrpc {
         listGroupStats(
             com.google.devtools.clouderrorreporting.v1beta1.ListGroupStatsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListGroupStatsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListGroupStatsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -515,7 +483,7 @@ public final class ErrorStatsServiceGrpc {
             com.google.devtools.clouderrorreporting.v1beta1.ListEventsResponse>
         listEvents(com.google.devtools.clouderrorreporting.v1beta1.ListEventsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListEventsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListEventsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -529,7 +497,7 @@ public final class ErrorStatsServiceGrpc {
             com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsResponse>
         deleteEvents(com.google.devtools.clouderrorreporting.v1beta1.DeleteEventsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteEventsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteEventsMethod(), getCallOptions()), request);
     }
   }
 
@@ -639,9 +607,9 @@ public final class ErrorStatsServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ErrorStatsServiceFileDescriptorSupplier())
-                      .addMethod(getListGroupStatsMethodHelper())
-                      .addMethod(getListEventsMethodHelper())
-                      .addMethod(getDeleteEventsMethodHelper())
+                      .addMethod(getListGroupStatsMethod())
+                      .addMethod(getListEventsMethod())
+                      .addMethod(getDeleteEventsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ReportErrorsServiceGrpc.java
+++ b/grpc-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/ReportErrorsServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/clouderrorreporting/v1beta1/report_errors_service.proto")
 public final class ReportErrorsServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class ReportErrorsServiceGrpc {
       "google.devtools.clouderrorreporting.v1beta1.ReportErrorsService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getReportErrorEventMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
-      METHOD_REPORT_ERROR_EVENT = getReportErrorEventMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
       getReportErrorEventMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ReportErrorEvent",
+      requestType = com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest.class,
+      responseType = com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
           com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
       getReportErrorEventMethod() {
-    return getReportErrorEventMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
-          com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
-      getReportErrorEventMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
             com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
@@ -79,10 +69,7 @@ public final class ReportErrorsServiceGrpc {
                           com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.clouderrorreporting.v1beta1.ReportErrorsService",
-                              "ReportErrorEvent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ReportErrorEvent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -103,19 +90,43 @@ public final class ReportErrorsServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ReportErrorsServiceStub newStub(io.grpc.Channel channel) {
-    return new ReportErrorsServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceStub>() {
+          @java.lang.Override
+          public ReportErrorsServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ReportErrorsServiceStub(channel, callOptions);
+          }
+        };
+    return ReportErrorsServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ReportErrorsServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ReportErrorsServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceBlockingStub>() {
+          @java.lang.Override
+          public ReportErrorsServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ReportErrorsServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return ReportErrorsServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ReportErrorsServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ReportErrorsServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ReportErrorsServiceFutureStub>() {
+          @java.lang.Override
+          public ReportErrorsServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ReportErrorsServiceFutureStub(channel, callOptions);
+          }
+        };
+    return ReportErrorsServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -145,14 +156,14 @@ public final class ReportErrorsServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getReportErrorEventMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getReportErrorEventMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getReportErrorEventMethodHelper(),
+              getReportErrorEventMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest,
@@ -170,11 +181,7 @@ public final class ReportErrorsServiceGrpc {
    * </pre>
    */
   public static final class ReportErrorsServiceStub
-      extends io.grpc.stub.AbstractStub<ReportErrorsServiceStub> {
-    private ReportErrorsServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ReportErrorsServiceStub> {
     private ReportErrorsServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -204,7 +211,7 @@ public final class ReportErrorsServiceGrpc {
                 com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getReportErrorEventMethodHelper(), getCallOptions()),
+          getChannel().newCall(getReportErrorEventMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -218,11 +225,7 @@ public final class ReportErrorsServiceGrpc {
    * </pre>
    */
   public static final class ReportErrorsServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<ReportErrorsServiceBlockingStub> {
-    private ReportErrorsServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ReportErrorsServiceBlockingStub> {
     private ReportErrorsServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -251,7 +254,7 @@ public final class ReportErrorsServiceGrpc {
         reportErrorEvent(
             com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest request) {
       return blockingUnaryCall(
-          getChannel(), getReportErrorEventMethodHelper(), getCallOptions(), request);
+          getChannel(), getReportErrorEventMethod(), getCallOptions(), request);
     }
   }
 
@@ -263,11 +266,7 @@ public final class ReportErrorsServiceGrpc {
    * </pre>
    */
   public static final class ReportErrorsServiceFutureStub
-      extends io.grpc.stub.AbstractStub<ReportErrorsServiceFutureStub> {
-    private ReportErrorsServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ReportErrorsServiceFutureStub> {
     private ReportErrorsServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -297,7 +296,7 @@ public final class ReportErrorsServiceGrpc {
         reportErrorEvent(
             com.google.devtools.clouderrorreporting.v1beta1.ReportErrorEventRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getReportErrorEventMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getReportErrorEventMethod(), getCallOptions()), request);
     }
   }
 
@@ -392,7 +391,7 @@ public final class ReportErrorsServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ReportErrorsServiceFileDescriptorSupplier())
-                      .addMethod(getReportErrorEventMethodHelper())
+                      .addMethod(getReportErrorEventMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -18,11 +18,10 @@ import synthtool as s
 import synthtool.gcp as gcp
 import synthtool.languages.java as java
 
-gapic = gcp.GAPICGenerator()
+gapic = gcp.GAPICBazel()
 
-service = 'error-reporting'
+service = 'devtools-clouderrorreporting'
 versions = ['v1beta1']
-config_pattern = '/google/devtools/clouderrorreporting/artman_errorreporting.yaml'
 
 ERROR_GROUP_OVERLOAD = """
   // Inserted by synthtool to preserve backwards-compatibility
@@ -64,30 +63,32 @@ for version in versions:
   library = gapic.java_library(
       service=service,
       version=version,
-      config_path=config_pattern.format(version=version),
-      artman_output_name='')
+      proto_path=f'google/devtools/clouderrorreporting/{version}',
+      bazel_target=f'//google/devtools/clouderrorreporting/{version}:google-cloud-{service}-{version}-java',
+  )
 
-  package_name = f'com.google.devtools.clouderrorreporting.{version}'
-  java.fix_proto_headers(library / f'proto-google-cloud-{service}-{version}')
-  java.fix_grpc_headers(library / f'grpc-google-cloud-{service}-{version}', package_name)
+  library = library / f"google-cloud-{service}-{version}-java"
+
+  java.fix_proto_headers(library / f'proto-google-cloud-{service}-{version}-java')
+  java.fix_grpc_headers(library / f'grpc-google-cloud-{service}-{version}-java', "")
 
   s.replace(
-      library / f'gapic-google-cloud-{service}-{version}/src/**/ErrorGroupServiceClient.java',
+      library / f'gapic-google-cloud-{service}-{version}-java/src/**/ErrorGroupServiceClient.java',
       ERROR_GROUP_OVERLOAD_PREVIOUS_METHOD,
       "\g<1>\n\n" + ERROR_GROUP_OVERLOAD
   )
   s.replace(
-      library / f'gapic-google-cloud-{service}-{version}/src/**/ErrorGroupServiceClient.java',
+      library / f'gapic-google-cloud-{service}-{version}-java/src/**/ErrorGroupServiceClient.java',
       "import com.google.devtools.clouderrorreporting.v1beta1.ErrorGroupName;",
       "import com.google.devtools.clouderrorreporting.v1beta1.ErrorGroupName;\nimport com.google.devtools.clouderrorreporting.v1beta1.GroupName;"
   )
 
-  s.copy(library / f'gapic-google-cloud-{service}-{version}/src', f'google-cloud-errorreporting/src')
-  s.copy(library / f'grpc-google-cloud-{service}-{version}/src', f'grpc-google-cloud-{service}-{version}/src')
-  s.copy(library / f'proto-google-cloud-{service}-{version}/src', f'proto-google-cloud-{service}-{version}/src')
+  s.copy(library / f'gapic-google-cloud-{service}-{version}-java/src', f'google-cloud-errorreporting/src')
+  s.copy(library / f'grpc-google-cloud-{service}-{version}-java/src', f'grpc-google-cloud-error-reporting-{version}/src')
+  s.copy(library / f'proto-google-cloud-{service}-{version}-java/src', f'proto-google-cloud-error-reporting-{version}/src')
 
   java.format_code(f'google-cloud-errorreporting/src')
-  java.format_code(f'grpc-google-cloud-{service}-{version}/src')
-  java.format_code(f'proto-google-cloud-{service}-{version}/src')
+  java.format_code(f'grpc-google-cloud-error-reporting-{version}/src')
+  java.format_code(f'proto-google-cloud-error-reporting-{version}/src')
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

