### PR TITLE
chore(fix): fix nightly test of samples

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -33,15 +33,6 @@
     <module>snippets</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>enable-samples</id>
-      <modules>
-        <module>sample</module>
-      </modules>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
nightly tests of samples fail due to profiles section that isn't defined well.
to align samples' pom.xml with other client library repositories, the section is removed.
